### PR TITLE
improve use of system liblz4

### DIFF
--- a/lz4.c
+++ b/lz4.c
@@ -35,6 +35,19 @@
 #include "lz4.h"
 #include "lz4hc.h"
 
+#if defined(LZ4HC_CLEVEL_MAX)
+/* version >= 1.7.5 */
+#define PHP_LZ4_CLEVEL_MAX LZ4HC_CLEVEL_MAX
+
+#elif defined (LZ4HC_MAX_CLEVEL)
+/* version >= 1.7.3 */
+#define PHP_LZ4_CLEVEL_MAX LZ4HC_MAX_CLEVEL
+
+#else
+/* older versions */
+#define PHP_LZ4_CLEVEL_MAX 16
+#endif
+
 static ZEND_FUNCTION(lz4_compress);
 static ZEND_FUNCTION(lz4_uncompress);
 
@@ -56,19 +69,40 @@ static zend_function_entry lz4_functions[] = {
     ZEND_FE_END
 };
 
+
+static PHP_MINIT_FUNCTION(lz4)
+{
+    REGISTER_LONG_CONSTANT("LZ4_CLEVEL_MAX", PHP_LZ4_CLEVEL_MAX, CONST_CS | CONST_PERSISTENT);
+
+    return SUCCESS;
+}
+
 ZEND_MINFO_FUNCTION(lz4)
 {
-    char buffer[128];
     php_info_print_table_start();
     php_info_print_table_row(2, "LZ4 support", "enabled");
     php_info_print_table_row(2, "Extension Version", LZ4_EXT_VERSION);
-#ifdef HAVE_LIBLZ4
-    snprintf(buffer, sizeof(buffer), "%s", "system library");
-#else
+#if !defined(HAVE_LIBLZ4)
+    /* Bundled library */
+    php_info_print_table_row(2, "LZ4 Version", LZ4_versionString());
+#elif defined(LZ4_VERSION_MAJOR)
+    /* Recent system library */
+    {
+    char buffer[128];
+
     snprintf(buffer, sizeof(buffer), "%d.%d.%d",
              LZ4_VERSION_MAJOR, LZ4_VERSION_MINOR, LZ4_VERSION_RELEASE);
+    php_info_print_table_row(2, "LZ4 headers Version", buffer);
+
+    /* LZ4_versionString is not usable, see https://github.com/lz4/lz4/issues/301 */
+    snprintf(buffer, sizeof(buffer), "%d.%d.%d",
+             LZ4_versionNumber()/10000, (LZ4_versionNumber()/100)%100, LZ4_versionNumber()%100);
+    php_info_print_table_row(2, "LZ4 library Version", buffer);
+    }
+#else
+    /* Old system library */
+    php_info_print_table_row(2, "LZ4 Version", "system library");
 #endif
-    php_info_print_table_row(2, "LZ4 Version", buffer);
     php_info_print_table_end();
 }
 
@@ -78,7 +112,7 @@ zend_module_entry lz4_module_entry = {
 #endif
     "lz4",
     lz4_functions,
-    NULL,
+    PHP_MINIT(lz4),
     NULL,
     NULL,
     NULL,
@@ -99,7 +133,7 @@ static ZEND_FUNCTION(lz4_compress)
     char *output;
     int output_len, data_len, dst_len;
     long level = 0;
-    long maxLevel = (long)LZ4HC_CLEVEL_MAX;
+    long maxLevel = (long)PHP_LZ4_CLEVEL_MAX;
     char *extra = NULL;
 #if ZEND_MODULE_API_NO >= 20141001
     size_t extra_len = -1;
@@ -147,7 +181,7 @@ static ZEND_FUNCTION(lz4_compress)
     } else {
         if (level > maxLevel || level < 0) {
             zend_error(E_WARNING, "lz4_compress: compression level (%ld)"
-                       " must be within 1..%d", level, maxLevel);
+                       " must be within 1..%ld", level, maxLevel);
             efree(output);
             RETURN_FALSE;
         }

--- a/lz4.c
+++ b/lz4.c
@@ -48,6 +48,19 @@
 #define PHP_LZ4_CLEVEL_MAX 16
 #endif
 
+#if defined(LZ4HC_CLEVEL_MIN)
+/* version >= 1.7.5 */
+#define PHP_LZ4_CLEVEL_MIN LZ4HC_CLEVEL_MIN
+
+#elif defined (LZ4HC_MIN_CLEVEL)
+/* version >= 1.7.3 */
+#define PHP_LZ4_CLEVEL_MIN LZ4HC_MIN_CLEVEL
+
+#else
+/* older versions */
+#define PHP_LZ4_CLEVEL_MIN 3
+#endif
+
 static ZEND_FUNCTION(lz4_compress);
 static ZEND_FUNCTION(lz4_uncompress);
 
@@ -72,7 +85,9 @@ static zend_function_entry lz4_functions[] = {
 
 static PHP_MINIT_FUNCTION(lz4)
 {
+    REGISTER_LONG_CONSTANT("LZ4_CLEVEL_MIN", PHP_LZ4_CLEVEL_MIN, CONST_CS | CONST_PERSISTENT);
     REGISTER_LONG_CONSTANT("LZ4_CLEVEL_MAX", PHP_LZ4_CLEVEL_MAX, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("LZ4_VERSION",    LZ4_versionNumber(), CONST_CS | CONST_PERSISTENT);
 
     return SUCCESS;
 }

--- a/tests/011.phpt
+++ b/tests/011.phpt
@@ -45,8 +45,8 @@ check_compress($data, -1);
 8 -- 2686 -- true
 9 -- 2686 -- true
 10 -- 2686 -- true
-11 -- 2683 -- true
-12 -- 2683 -- true
+11 -- 26%d -- true
+12 -- 26%d -- true
 *** Invalid Compression Level ***
 100 -- 0 -- false
 -1 -- 0 -- false


### PR DESCRIPTION
Minor improvments:
* expose LZ4_CLEVEL_MAX in user land
* dynamically detect LZ4_CLEVEL_MAX with various upstream versions
* improve library information in phpinfo (headers and library version may differ)
* allow test 011 to work with older versions (tested with 1.7.4)
* minor fix in a zend_error call (arg type)

Notice: **LZ4_versionNumber** exists since r200, **LZ4_versionString** is not available (for now) in shared library (export issue, see https://github.com/lz4/lz4/issues/301)
