### PR TITLE
Add support for Frame format

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ RPM packages of this extension are available in [» Remi's RPM repository](https
 
 DEB packages of this extension are available in [» Ondřej Surý's DEB repository](https://deb.sury.org/) and are named **php-lz4**.
 
+## Installation via PIE
+
+```bash
+pie install kjdev/lz4
+```
+
 
 ## Configuration
 
@@ -42,8 +48,10 @@ php.ini:
 
 ## Function
 
-* lz4\_compress — LZ4 compression
-* lz4\_uncompress — LZ4 decompression
+* lz4\_compress — LZ4 compression (block format)
+* lz4\_uncompress — LZ4 decompression (block format)
+* lz4\_compress\_frame — LZ4 compression (frame format)
+* lz4\_uncompress\_frame — LZ4 decompression (frame format)
 
 ### lz4\_compress — LZ4 compression
 
@@ -98,6 +106,75 @@ LZ4 decompression.
 #### Return Values
 
 Returns the decompressed data or FALSE if an error occurred.
+
+
+### lz4\_compress\_frame — LZ4 compression (frame format)
+
+#### Description
+
+string **lz4\_compress\_frame** ( string _$data_ [ , int _$level_ = 0 , int _$max_block_size_ = 0 , int _$checksums_ = 0 ] )
+
+LZ4 compression to frame.
+
+#### Pameters
+
+* _data_
+
+  The string to compress.
+
+* _level_
+
+  The level of compression (1-12, Recommended values are between 4 and 9).
+  (Default to 0, Not High Compression Mode.)
+
+* _max\_block\_size_
+
+  Maximum uncompressed size of each block.
+
+  * 4 = 64 KB
+  * 5 = 256 KB
+  * 6 = 1 MB
+  * 7 = 4 MB
+  * any other value: 64 KB
+
+* _checksums_
+
+  Enable/disable frame level and block level checksums.
+  The value is a bitmask using this bit interpretation:
+
+  * bit 0: frame level checksum
+  * bit 1: block level checksum
+
+  Which leads to the following:
+
+  * 0 = no checksums
+  * 1 = frame level checksum
+  * 2 = block level checksum
+  * 3 = both checksums
+
+#### Return Values
+
+Returns the compressed data or FALSE if an error occurred.
+
+
+### lz4\_uncompress\_frame — LZ4 decompression (frame format)
+
+#### Description
+
+string **lz4\_uncompress\_frame** ( string _$data_ )
+
+LZ4 decompression from frame.
+
+#### Pameters
+
+* _data_
+
+  The compressed string.
+
+#### Return Values
+
+Returns the decompressed data or FALSE if an error occurred.
+
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -130,27 +130,22 @@ LZ4 compression to frame.
 * _max\_block\_size_
 
   Maximum uncompressed size of each block.
+  Pass any of the following values:
 
-  * 4 = 64 KB
-  * 5 = 256 KB
-  * 6 = 1 MB
-  * 7 = 4 MB
-  * any other value: 64 KB
+  * _LZ4\_BLOCK\_SIZE\_64KB_
+  * _LZ4\_BLOCK\_SIZE\_256KB_
+  * _LZ4\_BLOCK\_SIZE\_1MB_
+  * _LZ4\_BLOCK\_SIZE\_4MB_
+  
+  Any other value will be treated as _LZ4\_BLOCK\_SIZE\_64KB_.
 
 * _checksums_
 
   Enable/disable frame level and block level checksums.
-  The value is a bitmask using this bit interpretation:
+  Pass a bitwise combination of the following constants:
 
-  * bit 0: frame level checksum
-  * bit 1: block level checksum
-
-  Which leads to the following:
-
-  * 0 = no checksums
-  * 1 = frame level checksum
-  * 2 = block level checksum
-  * 3 = both checksums
+  * _LZ4\_CHECKSUM\_FRAME_: frame level checksum
+  * _LZ4\_CHECKSUM\_BLOCK_: block level checksum
 
 #### Return Values
 

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ LZ4 compression to frame.
 
 * _checksums_
 
-  Enable/disable frame level and block level checksums.
+  Enable/disable frame-level and block-level checksums.
   Pass a bitwise combination of the following constants:
 
-  * _LZ4\_CHECKSUM\_FRAME_: frame level checksum
-  * _LZ4\_CHECKSUM\_BLOCK_: block level checksum
+  * _LZ4\_CHECKSUM\_FRAME_: frame-level checksum
+  * _LZ4\_CHECKSUM\_BLOCK_: block-level checksum
 
 #### Return Values
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ string **lz4\_compress** ( string _$data_ [ , int _$level_ = 0 , string _$extra_
 
 LZ4 compression.
 
-#### Pameters
+#### Parameters
 
 * _data_
 
@@ -89,7 +89,7 @@ string **lz4\_uncompress** ( string _$data_ [ , long _$maxsize_ = -1 , long _$of
 
 LZ4 decompression.
 
-#### Pameters
+#### Parameters
 
 * _data_
 
@@ -116,7 +116,7 @@ string **lz4\_compress\_frame** ( string _$data_ [ , int _$level_ = 0 , int _$ma
 
 LZ4 compression to frame.
 
-#### Pameters
+#### Parameters
 
 * _data_
 
@@ -160,7 +160,7 @@ string **lz4\_uncompress\_frame** ( string _$data_ )
 
 LZ4 decompression from frame.
 
-#### Pameters
+#### Parameters
 
 * _data_
 

--- a/config.m4
+++ b/config.m4
@@ -59,7 +59,7 @@ if test "$PHP_LZ4" != "no"; then
   else
     AC_MSG_RESULT(use bundled version)
 
-    PHP_NEW_EXTENSION(lz4, lz4.c lz4/lib/lz4.c lz4/lib/lz4hc.c lz4/lib/xxhash.c, $ext_shared)
+    PHP_NEW_EXTENSION(lz4, lz4.c lz4/lib/lz4.c lz4/lib/lz4hc.c lz4/lib/lz4frame.c lz4/lib/xxhash.c, $ext_shared)
 
     PHP_ADD_BUILD_DIR($ext_builddir/lz4/lib, 1)
     PHP_ADD_INCLUDE([$ext_srcdir/lz4/lib])

--- a/config.w32
+++ b/config.w32
@@ -6,7 +6,7 @@ if (PHP_LZ4 != "no") {
     EXTENSION("lz4", "lz4.c", PHP_LZ4_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
   } else {
     EXTENSION("lz4", "lz4.c", PHP_LZ4_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
-    ADD_SOURCES("lz4/lib", "lz4.c lz4hc.c xxhash.c", "lz4", "lz4\\lib");
+    ADD_SOURCES("lz4/lib", "lz4.c lz4frame.c lz4hc.c xxhash.c", "lz4", "lz4\\lib");
     ADD_FLAG("CFLAGS_LZ4", " /I" + configure_module_dirname + " /I" + configure_module_dirname + "/lz4/lib");
   }
   PHP_INSTALL_HEADERS("ext/lz4/", "php_lz4.h");

--- a/lz4.c
+++ b/lz4.c
@@ -39,6 +39,7 @@
 /* lz4 */
 #include "lz4.h"
 #include "lz4hc.h"
+#include "lz4frame.h"
 
 #if defined(LZ4HC_CLEVEL_MAX)
 /* version >= 1.7.5 */
@@ -68,6 +69,8 @@
 
 static ZEND_FUNCTION(lz4_compress);
 static ZEND_FUNCTION(lz4_uncompress);
+static ZEND_FUNCTION(lz4_compress_frame);
+static ZEND_FUNCTION(lz4_uncompress_frame);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_lz4_compress, 0, 0, 1)
     ZEND_ARG_INFO(0, data)
@@ -81,6 +84,17 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_lz4_uncompress, 0, 0, 1)
     ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_lz4_compress_frame, 0, 0, 1)
+    ZEND_ARG_INFO(0, data)
+    ZEND_ARG_INFO(0, level)
+    ZEND_ARG_INFO(0, max_block_size)
+    ZEND_ARG_INFO(0, checksums)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_lz4_uncompress_frame, 0, 0, 1)
+    ZEND_ARG_INFO(0, data)
+ZEND_END_ARG_INFO()
+
 #if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
 static int APC_SERIALIZER_NAME(lz4)(APC_SERIALIZER_ARGS);
 static int APC_UNSERIALIZER_NAME(lz4)(APC_UNSERIALIZER_ARGS);
@@ -89,6 +103,8 @@ static int APC_UNSERIALIZER_NAME(lz4)(APC_UNSERIALIZER_ARGS);
 static zend_function_entry lz4_functions[] = {
     ZEND_FE(lz4_compress, arginfo_lz4_compress)
     ZEND_FE(lz4_uncompress, arginfo_lz4_uncompress)
+    ZEND_FE(lz4_compress_frame, arginfo_lz4_compress_frame)
+    ZEND_FE(lz4_uncompress_frame, arginfo_lz4_uncompress_frame)
     ZEND_FE_END
 };
 
@@ -260,6 +276,158 @@ static int php_lz4_uncompress(const char* in, const int in_len,
     return SUCCESS;
 }
 
+/**
+ * @param max_block_size 4: 64KB, 5: 256KB, 6: 1MB, 7: 4MB, all other values: 64KB
+ * @param checksums 0: none, 1: frame content, 2: each block, 3: frame content + each block
+ */
+static int php_lz4_compress_frame(char* in, const int in_len,
+                                  char** out, int* out_len,
+                                  const int level,
+                                  int max_block_size,
+                                  const int checksums)
+{
+    int var_len;
+    LZ4F_preferences_t preferences = LZ4F_INIT_PREFERENCES;
+
+    var_len = LZ4F_compressFrameBound(in_len, &preferences);
+
+    *out = (char*)emalloc(var_len);
+    if (!*out) {
+        zend_error(E_WARNING, "lz4_compress_frame : memory error");
+        *out_len = 0;
+        return FAILURE;
+    }
+
+    if (max_block_size < 4 || max_block_size > 7) {
+        max_block_size = 0;
+    }
+    preferences.frameInfo.blockSizeID = max_block_size;
+    preferences.frameInfo.contentSize = in_len;
+    preferences.frameInfo.contentChecksumFlag = checksums & 0x01;
+    preferences.frameInfo.blockChecksumFlag = (checksums & 0x02) >> 1;
+    preferences.compressionLevel = level;
+
+    *out_len = LZ4F_compressFrame(*out, var_len, in, in_len, &preferences);
+
+    if (*out_len <= 0) {
+        zend_error(E_WARNING, "lz4_compress_frame : data error");
+        efree(*out);
+        *out = NULL;
+        *out_len = 0;
+        return FAILURE;
+    }
+
+    return SUCCESS;
+}
+
+static size_t get_block_size(const LZ4F_frameInfo_t *frame_info)
+{
+    switch (frame_info->blockSizeID) {
+        case LZ4F_max256KB: return 1 << 18;
+        case LZ4F_max1MB: return 1 << 20;
+        case LZ4F_max4MB: return 1 << 22;
+        default: return 1 << 16;        // 64kibi
+    }
+}
+
+static int php_lz4_uncompress_frame(const char* in, const int in_len,
+                                    char** out, unsigned long int* out_len)
+{
+    LZ4F_dctx* dctx;
+    LZ4F_errorCode_t err;
+    size_t size_next, in_offset, out_offset, in_size_consumed, out_size_decompressed, block_size;
+    LZ4F_frameInfo_t frame_info;
+    LZ4F_decompressOptions_t decomp_options = { 0u, 0u, 0u, 0u };
+
+    err = LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION);
+    if (LZ4F_isError(err)) {
+        zend_error(E_WARNING, 
+                   "lz4_uncompress_frame : create decompression context (%s)",
+                   LZ4F_getErrorName(err));
+        return FAILURE;
+    }
+
+    in_size_consumed = LZ4F_HEADER_SIZE_MAX;
+    size_next = LZ4F_getFrameInfo(dctx, &frame_info, in, &in_size_consumed);
+    if (LZ4F_isError(size_next)) {
+        zend_error(E_WARNING, 
+                   "lz4_uncompress_frame : create decompression context (%s)",
+                   LZ4F_getErrorName(size_next));
+        LZ4F_freeDecompressionContext(dctx);
+        return FAILURE;
+    }
+
+    block_size = get_block_size(&frame_info);
+    *out_len = block_size;
+    if (frame_info.contentSize > 0) {
+        *out_len = frame_info.contentSize;
+    }
+    *out = (char*)malloc(*out_len);
+    if (!*out) {
+        zend_error(E_WARNING, "lz4_uncompress_frame : memory error");
+        LZ4F_freeDecompressionContext(dctx);
+        return FAILURE;
+    }
+
+    in_offset = in_size_consumed;
+    out_offset = 0;
+    while (size_next > 0) {
+        if (frame_info.contentSize == 0 && *out_len - out_offset < block_size) {
+            *out_len += block_size * 3;
+            *out = (char*)realloc(*out, *out_len);
+            if (!*out) {
+                zend_error(E_WARNING, "lz4_uncompress_frame : memory error");
+                LZ4F_freeDecompressionContext(dctx);
+                return FAILURE;
+            }
+        }
+
+        in_size_consumed = size_next;
+        out_size_decompressed = *out_len - out_offset;
+
+        size_next = LZ4F_decompress(dctx,
+                                (*out) + out_offset,
+                                &out_size_decompressed,
+                                in + in_offset,
+                                &in_size_consumed,
+                                &decomp_options);
+        if (LZ4F_isError(size_next)) {
+            zend_error(E_WARNING, 
+                       "lz4_uncompress_frame : data error (%s)",
+                       LZ4F_getErrorName(size_next));
+            LZ4F_freeDecompressionContext(dctx);
+            free(*out);
+            *out = NULL;
+            *out_len = 0;
+            return FAILURE;
+        }
+        
+        in_offset += in_size_consumed;
+        out_offset += out_size_decompressed;
+
+        if (in_size_consumed == 0) {
+            zend_error(E_WARNING, 
+                       "lz4_uncompress_frame : data error (unexpected uncompressed data size)");
+            LZ4F_freeDecompressionContext(dctx);
+            free(*out);
+            *out = NULL;
+            *out_len = 0;
+            return FAILURE;
+        }
+    }
+    *out_len = out_offset;
+
+    err = LZ4F_freeDecompressionContext(dctx);
+    if (LZ4F_isError(err)) {
+        zend_error(E_WARNING, 
+                   "lz4_uncompress_frame : free decompression context (%s)",
+                   LZ4F_getErrorName(err));
+        return FAILURE;
+    }
+
+    return SUCCESS;
+}
+
 static ZEND_FUNCTION(lz4_compress)
 {
     zval *data;
@@ -324,6 +492,74 @@ static ZEND_FUNCTION(lz4_uncompress)
 
     if (php_lz4_uncompress(Z_STRVAL_P(data), Z_STRLEN_P(data),
                            (const int)max_size, (const int)offset,
+                           &output, &output_len) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+#if ZEND_MODULE_API_NO >= 20141001
+    RETVAL_STRINGL(output, output_len);
+#else
+    RETVAL_STRINGL(output, output_len, 1);
+#endif
+
+    free(output);
+}
+
+static ZEND_FUNCTION(lz4_compress_frame)
+{
+    zval *data;
+    char *output;
+    int output_len;
+    long level = 0;
+    long max_block_size = 0;
+    long checksums = 0;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC,
+                              "z|lll", &data, &level,
+                              &max_block_size, &checksums) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+    if (Z_TYPE_P(data) != IS_STRING) {
+        zend_error(E_WARNING,
+                   "lz4_compress : expects parameter to be string.");
+        RETURN_FALSE;
+    }
+
+    if (php_lz4_compress_frame(Z_STRVAL_P(data), Z_STRLEN_P(data),
+                               &output, &output_len,
+                               (int)level,
+                               (int)max_block_size,
+                               (int)checksums) == FAILURE) {
+        RETVAL_FALSE;
+    }
+#if ZEND_MODULE_API_NO >= 20141001
+    RETVAL_STRINGL(output, output_len);
+#else
+    RETVAL_STRINGL(output, output_len, 1);
+#endif
+
+    efree(output);
+}
+
+static ZEND_FUNCTION(lz4_uncompress_frame)
+{
+    zval *data;
+    unsigned long int output_len;
+    char *output;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC,
+                              "z", &data) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+    if (Z_TYPE_P(data) != IS_STRING) {
+        zend_error(E_WARNING,
+                   "lz4_uncompress : expects parameter to be string.");
+        RETURN_FALSE;
+    }
+
+    if (php_lz4_uncompress_frame(Z_STRVAL_P(data), Z_STRLEN_P(data),
                            &output, &output_len) == FAILURE) {
         RETURN_FALSE;
     }

--- a/lz4.c
+++ b/lz4.c
@@ -374,12 +374,16 @@ static int php_lz4_uncompress_frame(const char* in, const int in_len,
     while (size_next > 0) {
         if (frame_info.contentSize == 0 && *out_len - out_offset < block_size) {
             *out_len += block_size * 3;
-            *out = (char*)realloc(*out, *out_len);
-            if (!*out) {
+            char *tmp = (char*)realloc(*out, *out_len);
+            if (!*tmp) {
                 zend_error(E_WARNING, "lz4_uncompress_frame : memory error");
                 LZ4F_freeDecompressionContext(dctx);
+                free(*out);
+                *out = NULL;
+                *out_len = 0;
                 return FAILURE;
             }
+            *out = tmp;
         }
 
         in_size_consumed = size_next;
@@ -531,7 +535,7 @@ static ZEND_FUNCTION(lz4_compress_frame)
                                (int)level,
                                (int)max_block_size,
                                (int)checksums) == FAILURE) {
-        RETVAL_FALSE;
+        RETURN_FALSE;
     }
 #if ZEND_MODULE_API_NO >= 20141001
     RETVAL_STRINGL(output, output_len);

--- a/lz4.c
+++ b/lz4.c
@@ -67,6 +67,9 @@
 #define PHP_LZ4_CLEVEL_MIN 3
 #endif
 
+#define PHP_LZ4_CHECKSUM_FRAME (1<<0)
+#define PHP_LZ4_CHECKSUM_BLOCK (1<<1)
+
 static ZEND_FUNCTION(lz4_compress);
 static ZEND_FUNCTION(lz4_uncompress);
 static ZEND_FUNCTION(lz4_compress_frame);
@@ -115,6 +118,12 @@ static PHP_MINIT_FUNCTION(lz4)
     REGISTER_LONG_CONSTANT("LZ4_CLEVEL_MAX", PHP_LZ4_CLEVEL_MAX, CONST_CS | CONST_PERSISTENT);
     REGISTER_LONG_CONSTANT("LZ4_VERSION_NUMBER", LZ4_versionNumber(), CONST_CS | CONST_PERSISTENT);
     REGISTER_STRING_CONSTANT("LZ4_VERSION_TEXT", (char *)LZ4_versionString(), CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("LZ4_CHECKSUM_FRAME", PHP_LZ4_CHECKSUM_FRAME, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("LZ4_CHECKSUM_BLOCK", PHP_LZ4_CHECKSUM_BLOCK, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("LZ4_BLOCK_SIZE_64KB", LZ4F_max64KB, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("LZ4_BLOCK_SIZE_256KB", LZ4F_max256KB, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("LZ4_BLOCK_SIZE_1MB", LZ4F_max1MB, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("LZ4_BLOCK_SIZE_4MB", LZ4F_max4MB, CONST_CS | CONST_PERSISTENT);
 
 #if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
     apc_register_serializer("lz4",
@@ -294,8 +303,8 @@ static int php_lz4_compress_frame(char* in, const int in_len,
     }
     preferences.frameInfo.blockSizeID = max_block_size;
     preferences.frameInfo.contentSize = in_len;
-    preferences.frameInfo.contentChecksumFlag = checksums & 0x01;
-    preferences.frameInfo.blockChecksumFlag = (checksums & 0x02) >> 1;
+    preferences.frameInfo.contentChecksumFlag = (checksums & PHP_LZ4_CHECKSUM_FRAME) > 0;
+    preferences.frameInfo.blockChecksumFlag = (checksums & PHP_LZ4_CHECKSUM_BLOCK) > 0;
     preferences.compressionLevel = level;
 
     var_len = LZ4F_compressFrameBound(in_len, &preferences);

--- a/lz4.stub.php
+++ b/lz4.stub.php
@@ -32,6 +32,10 @@ namespace {
 
   function lz4_uncompress(string $data, int $maxsize = -1, int $offset = -1): string|false {}
 
+  /**
+   * @param int $max_block_size 4: 64KB, 5: 256KB, 6: 1MB, 7: 4MB, all other values: 64KB
+   * @param int $checksums 0: none, 1: frame content, 2: each block, 3: frame content + each block
+   */
   function lz4_compress_frame(string $data, int $level = 0, int $max_block_size = 0, int $checksums = 0): string|false {}
 
 

--- a/lz4.stub.php
+++ b/lz4.stub.php
@@ -26,6 +26,42 @@ namespace {
    */
   const LZ4_VERSION_NUMBER = UNKNOWN;
 
+  /**
+   * @var int
+   * @cvalue LZ4_CHECKSUM_FRAME
+   */
+  const LZ4_CHECKSUM_FRAME = UNKNOWN;
+
+  /**
+   * @var int
+   * @cvalue LZ4_CHECKSUM_BLOCK
+   */
+  const LZ4_CHECKSUM_BLOCK = UNKNOWN;
+
+  /**
+   * @var int
+   * @cvalue LZ4_BLOCK_SIZE_64KB
+   */
+  const LZ4_BLOCK_SIZE_64KB = UNKNOWN;
+
+  /**
+   * @var int
+   * @cvalue LZ4_BLOCK_SIZE_256KB
+   */
+  const LZ4_BLOCK_SIZE_256KB = UNKNOWN;
+
+  /**
+   * @var int
+   * @cvalue LZ4_BLOCK_SIZE_1MB
+   */
+  const LZ4_BLOCK_SIZE_1MB = UNKNOWN;
+
+  /**
+   * @var int
+   * @cvalue LZ4_BLOCK_SIZE_4MB
+   */
+  const LZ4_BLOCK_SIZE_4MB = UNKNOWN;
+
 
   function lz4_compress(string $data, int $level = 0, string $extra = NULL): string|false {}
 
@@ -33,8 +69,8 @@ namespace {
   function lz4_uncompress(string $data, int $maxsize = -1, int $offset = -1): string|false {}
 
   /**
-   * @param int $max_block_size 4: 64KB, 5: 256KB, 6: 1MB, 7: 4MB, all other values: 64KB
-   * @param int $checksums 0: none, 1: frame content, 2: each block, 3: frame content + each block
+   * @param int $max_block_size any of the LZ4_BLOCK_SIZE_* constants
+   * @param int $checksums bitmask of the LZ4_CHECKSUM_* constants
    */
   function lz4_compress_frame(string $data, int $level = 0, int $max_block_size = 0, int $checksums = 0): string|false {}
 

--- a/lz4.stub.php
+++ b/lz4.stub.php
@@ -32,4 +32,9 @@ namespace {
 
   function lz4_uncompress(string $data, int $maxsize = -1, int $offset = -1): string|false {}
 
+  function lz4_compress_frame(string $data, int $level = 0, int $max_block_size = 0, int $checksums = 0): string|false {}
+
+
+  function lz4_uncompress_frame(string $data): string|false {}
+
 }

--- a/tests/frame_001.phpt
+++ b/tests/frame_001.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test lz4_compress_frame() function : basic functionality
+--SKIPIF--
+--FILE--
+<?php
+if (!extension_loaded('lz4')) {
+    dl('lz4.' . PHP_SHLIB_SUFFIX);
+}
+
+include(dirname(__FILE__) . '/data.inc');
+
+echo "*** Testing lz4_compress_frame() : basic functionality ***\n";
+
+// Initialise all required variables
+
+$smallstring = "A small string to compress\n";
+
+// Compressing a big string
+echo "-- Compression --\n";
+$output = lz4_compress_frame($data);
+var_dump(strcmp(lz4_uncompress_frame($output), $data));
+
+// Compressing a smaller string
+echo "-- Compression --\n";
+$output = lz4_compress_frame($smallstring);
+var_dump(bin2hex($output));
+var_dump(strcmp(lz4_uncompress_frame($output), $smallstring));
+?>
+===Done===
+--EXPECT--
+*** Testing lz4_compress_frame() : basic functionality ***
+-- Compression --
+int(0)
+-- Compression --
+string(100) "04224d1868401b00000000000000fa1b0000804120736d616c6c20737472696e6720746f20636f6d70726573730a00000000"
+int(0)
+===Done===

--- a/tests/frame_002.phpt
+++ b/tests/frame_002.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test lz4_compress_frame() function : with all parameters
+--SKIPIF--
+--FILE--
+<?php
+if (!extension_loaded('lz4')) {
+    dl('lz4.' . PHP_SHLIB_SUFFIX);
+}
+
+include(dirname(__FILE__) . '/data.inc');
+
+echo "*** Testing lz4_compress_frame() : with all parameters ***\n";
+
+// Initialise all required variables
+
+$smallstring = "A small string to compress\n";
+
+// Compressing a big string
+echo "-- Compression --\n";
+$output = lz4_compress_frame($data, 6, LZ4_BLOCK_SIZE_256KB, LZ4_CHECKSUM_FRAME | LZ4_CHECKSUM_BLOCK);
+var_dump(strcmp(lz4_uncompress_frame($output), $data));
+
+// Compressing a smaller string
+echo "-- Compression --\n";
+$output = lz4_compress_frame($smallstring, 6, LZ4_BLOCK_SIZE_256KB, LZ4_CHECKSUM_FRAME | LZ4_CHECKSUM_BLOCK);
+var_dump(bin2hex($output));
+var_dump(strcmp(lz4_uncompress_frame($output), $smallstring));
+?>
+===Done===
+--EXPECT--
+*** Testing lz4_compress_frame() : with all parameters ***
+-- Compression --
+int(0)
+-- Compression --
+string(116) "04224d187c401b00000000000000981b0000804120736d616c6c20737472696e6720746f20636f6d70726573730a2f4da318000000002f4da318"
+int(0)
+===Done===


### PR DESCRIPTION
Added two exported functions:

1. `lz4_compress_frame`
2. `lz4_uncompress_frame`

Both functions work similar to the already existing ones, except they handle the LZ4 Frame format instead of the Block format. The difference is of advantage if you need checksums or magic bytes.

Also added a pretty basic test case.

I look forward to reading your thoughts on this.

See also: #34 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added frame-format compression/decompression APIs with configurable level, block size, and checksum options; introduced public constants for checksums and block sizes.

* **Tests**
  * Added PHPT tests validating round-trip integrity and parameterized frame compression behavior.

* **Documentation**
  * Documented new frame-format APIs, clarified function labeling, and added installation guidance.

* **Chores**
  * Included bundled framing source in the extension build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->