### PR TITLE
Enhance APCu include detection for in-tree builds

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -81,6 +81,7 @@ if test "$PHP_LZ4" != "no"; then
       fi
       AC_MSG_RESULT([not found])
     fi
+  fi
 fi
 
 dnl coverage

--- a/config.m4
+++ b/config.m4
@@ -27,6 +27,9 @@ PHP_ARG_ENABLE(lz4, whether to enable lz4 support,
 PHP_ARG_WITH(lz4-includedir, for lz4 header,
 [  --with-lz4-includedir=DIR  lz4 header files], no, no)
 
+PHP_ARG_ENABLE(apcu, whether to enable APCu support,
+[  --enable-apcu           Enable APCu support], auto, no)
+
 if test "$PHP_LZ4" != "no"; then
 
   AC_MSG_CHECKING([searching for liblz4])

--- a/config.m4
+++ b/config.m4
@@ -65,14 +65,22 @@ if test "$PHP_LZ4" != "no"; then
     PHP_ADD_INCLUDE([$ext_srcdir/lz4/lib])
   fi
 
-  AC_MSG_CHECKING([for APCu includes])
-  if test -f "$phpincludedir/ext/apcu/apc_serializer.h"; then
-    apc_inc_path="$phpincludedir"
-    AC_MSG_RESULT([APCu in $apc_inc_path])
-    AC_DEFINE(HAVE_APCU_SUPPORT,1,[Whether to enable APCu support])
-  else
-    AC_MSG_RESULT([not found])
-  fi
+  dnl APCu
+  if test "$PHP_APCU" != "no"; then
+    AC_MSG_CHECKING([for APCu includes])
+    if test ! -f "$phpincludedir/ext/apcu/apc_serializer.h" && test -f "$abs_srcdir/ext/apcu/apc_serializer.h"; then
+      phpincludedir="$abs_srcdir"
+    fi
+    if test -f "$phpincludedir/ext/apcu/apc_serializer.h"; then
+      apc_inc_path="$phpincludedir"
+      AC_MSG_RESULT([APCu in $apc_inc_path])
+      AC_DEFINE(HAVE_APCU_SUPPORT, 1, [Whether to enable APCu support])
+    else
+      if test "$PHP_APCU" != "auto"; then
+        AC_MSG_ERROR([apc_serializer.h header not found])
+      fi
+      AC_MSG_RESULT([not found])
+    fi
 fi
 
 dnl coverage


### PR DESCRIPTION
see https://github.com/kjdev/php-ext-zstd/pull/100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved APCu detection during setup so it more accurately finds support when available.
  * Reduced unnecessary setup failures by treating missing APCu support as a non-fatal result in automatic detection mode.
  * Installation now better handles custom source layouts when checking for APCu compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->