### PR TITLE
configurable compression level for apcu 

### DIFF
--- a/lz4.c
+++ b/lz4.c
@@ -111,6 +111,16 @@ static zend_function_entry lz4_functions[] = {
     ZEND_FE_END
 };
 
+ZEND_DECLARE_MODULE_GLOBALS(lz4);
+
+#if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
+PHP_INI_BEGIN()
+    STD_PHP_INI_ENTRY("lz4.apcu_compression_level",
+                    "0",
+                    PHP_INI_ALL, OnUpdateLong, apcu_compression_level,
+                    zend_lz4_globals, lz4_globals)
+PHP_INI_END()
+#endif
 
 static PHP_MINIT_FUNCTION(lz4)
 {
@@ -130,8 +140,16 @@ static PHP_MINIT_FUNCTION(lz4)
                             APC_SERIALIZER_NAME(lz4),
                             APC_UNSERIALIZER_NAME(lz4),
                             NULL);
+    REGISTER_INI_ENTRIES();
 #endif
+    return SUCCESS;
+}
 
+PHP_MSHUTDOWN_FUNCTION(lz4)
+{
+#if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
+    UNREGISTER_INI_ENTRIES();
+#endif
     return SUCCESS;
 }
 
@@ -145,6 +163,16 @@ ZEND_MINFO_FUNCTION(lz4)
     php_info_print_table_row(2, "LZ4 APCu serializer ABI", APC_SERIALIZER_ABI);
 #endif
     php_info_print_table_end();
+#if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
+    DISPLAY_INI_ENTRIES();
+#endif
+}
+
+ZEND_GINIT_FUNCTION(lz4)
+{
+#if defined(ZTS)
+    ZEND_TSRMLS_CACHE_UPDATE();
+#endif
 }
 
 #if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
@@ -159,20 +187,22 @@ zend_module_entry lz4_module_entry = {
     STANDARD_MODULE_HEADER_EX,
     NULL,
     lz4_module_deps,
-#elif ZEND_MODULE_API_NO >= 20010901
+#else
     STANDARD_MODULE_HEADER,
 #endif
     "lz4",
     lz4_functions,
     PHP_MINIT(lz4),
-    NULL,
+    PHP_MSHUTDOWN(lz4),
     NULL,
     NULL,
     ZEND_MINFO(lz4),
-#if ZEND_MODULE_API_NO >= 20010901
     LZ4_EXT_VERSION,
-#endif
-    STANDARD_MODULE_PROPERTIES
+    PHP_MODULE_GLOBALS(lz4),
+    PHP_GINIT(lz4),
+    NULL,
+    NULL,
+    STANDARD_MODULE_PROPERTIES_EX
 };
 
 #ifdef COMPILE_DL_LZ4
@@ -594,6 +624,11 @@ static int APC_SERIALIZER_NAME(lz4)(APC_SERIALIZER_ARGS)
     php_serialize_data_t var_hash;
     int out_len, data_size, data_offset = sizeof(int);
     smart_str var = {0};
+    zend_long level = LZ4_G(apcu_compression_level);
+
+    if (level < 0 || level > PHP_LZ4_CLEVEL_MAX) {
+        level = 0;
+    }
 
     PHP_VAR_SERIALIZE_INIT(var_hash);
     php_var_serialize(&var, (zval*) value, &var_hash);
@@ -605,7 +640,7 @@ static int APC_SERIALIZER_NAME(lz4)(APC_SERIALIZER_ARGS)
     if (php_lz4_compress(ZSTR_VAL(var.s), ZSTR_LEN(var.s),
                          NULL, 0,
                          (char**)buf, (int*)buf_len,
-                         0) == SUCCESS) {
+                         (int)level) == SUCCESS) {
         result = 1;
     } else {
         result = 0;

--- a/php_lz4.h
+++ b/php_lz4.h
@@ -41,6 +41,14 @@ extern zend_module_entry lz4_module_entry;
 #include "TSRM.h"
 #endif
 
+ZEND_BEGIN_MODULE_GLOBALS(lz4)
+#if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
+    zend_long apcu_compression_level;
+#else
+    int unused_dummy;
+#endif
+ZEND_END_MODULE_GLOBALS(lz4);
+
 #ifdef ZTS
 #define LZ4_G(v) TSRMG(lz4_globals_id, zend_lz4_globals *, v)
 #else

--- a/tests/apcu_serializer.phpt
+++ b/tests/apcu_serializer.phpt
@@ -69,6 +69,33 @@ var_dump($unserialized);
 if ($unserialized[0] === $unserialized[1]) {
   echo "SAME\n";
 }
+
+
+function getEntrySize(string $key) {
+  $info = apcu_cache_info();
+  if (!is_array($info) || !isset($info['cache_list']) || !is_array($info['cache_list'])) {
+    return null;
+  }
+  foreach($info['cache_list'] as $entry) {
+    if (($entry['info'] ?? null) === $key) {
+      return $entry['mem_size'];
+    }
+  }
+  return null;
+}
+include(dirname(__FILE__) . '/data.inc');
+
+ini_set('lz4.apcu_compression_level', LZ4_CLEVEL_MIN);
+apcu_store('size_test', [$data]);
+$a = getEntrySize('size_test');
+
+ini_set('lz4.apcu_compression_level', LZ4_CLEVEL_MAX);
+apcu_store('size_test', [$data]);
+$b = getEntrySize('size_test');
+
+if ($a !== null && $b !== null && $b < $a) {
+  echo "SMALLER\n";
+}
 ?>
 --EXPECTF--
 lz4
@@ -108,3 +135,4 @@ array(2) {
   }
 }
 SAME
+SMALLER


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `lz4.apcu_compression_level` INI setting to control APCu LZ4 compression level (invalid values are reset to the default, within the supported range).
  * APCu serialization now uses the configured compression level.

* **Tests**
  * Updated the APCu serializer test to compare APCu entry `mem_size` between min and max compression levels, validating that higher compression can reduce stored entry size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->