### PR TITLE
Phpinfo improvements (+ fix warnings)

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -66,6 +66,7 @@ if test "$PHP_LZ4" != "no"; then
 
     PHP_ADD_BUILD_DIR($ext_builddir/lz4/lib, 1)
     PHP_ADD_INCLUDE([$ext_srcdir/lz4/lib])
+    AC_DEFINE(HAVE_BUNDLED_LZ4, 1, [Bundled lz4])
   fi
 
   dnl APCu

--- a/config.w32
+++ b/config.w32
@@ -8,6 +8,7 @@ if (PHP_LZ4 != "no") {
     EXTENSION("lz4", "lz4.c", PHP_LZ4_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
     ADD_SOURCES("lz4/lib", "lz4.c lz4frame.c lz4hc.c xxhash.c", "lz4", "lz4\\lib");
     ADD_FLAG("CFLAGS_LZ4", " /I" + configure_module_dirname + " /I" + configure_module_dirname + "/lz4/lib");
+    AC_DEFINE("HAVE_BUNDLED_LZ4", 1, "Bundled lz4");
   }
   PHP_INSTALL_HEADERS("ext/lz4/", "php_lz4.h");
 }

--- a/lz4.c
+++ b/lz4.c
@@ -626,7 +626,6 @@ static int APC_SERIALIZER_NAME(lz4)(APC_SERIALIZER_ARGS)
 {
     int result;
     php_serialize_data_t var_hash;
-    int out_len, data_size, data_offset = sizeof(int);
     smart_str var = {0};
     zend_long level = LZ4_G(apcu_compression_level);
 
@@ -660,7 +659,7 @@ static int APC_UNSERIALIZER_NAME(lz4)(APC_UNSERIALIZER_ARGS)
     const unsigned char* tmp;
     int result;
     php_unserialize_data_t var_hash;
-    int var_len, data_size, data_offset = sizeof(int);
+    int var_len = sizeof(int);
     unsigned char* var;
 
     if (php_lz4_uncompress((const char *)buf, (const int)buf_len,

--- a/lz4.c
+++ b/lz4.c
@@ -663,7 +663,7 @@ static int APC_UNSERIALIZER_NAME(lz4)(APC_UNSERIALIZER_ARGS)
     int var_len, data_size, data_offset = sizeof(int);
     unsigned char* var;
 
-    if (php_lz4_uncompress(buf, (const int)buf_len,
+    if (php_lz4_uncompress((const char *)buf, (const int)buf_len,
                            0, 0,
                            (char**)&var, (int*)&var_len) != SUCCESS) {
         ZVAL_NULL(value);

--- a/lz4.c
+++ b/lz4.c
@@ -156,11 +156,27 @@ PHP_MSHUTDOWN_FUNCTION(lz4)
 ZEND_MINFO_FUNCTION(lz4)
 {
     php_info_print_table_start();
-    php_info_print_table_row(2, "LZ4 support", "enabled");
-    php_info_print_table_row(2, "Extension Version", LZ4_EXT_VERSION);
-    php_info_print_table_row(2, "LZ4 Version", (char *)LZ4_versionString());
+    php_info_print_table_row(2, "Extension version", LZ4_EXT_VERSION);
+#if defined(HAVE_BUNDLED_LZ4)
+    php_info_print_table_row(2, "LZ4 library", "bundled");
+#else
+    php_info_print_table_row(2, "LZ4 library", "external");
+#endif
+    php_info_print_table_row(2, "LZ4 library version", (char *)LZ4_versionString());
 #if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)
-    php_info_print_table_row(2, "LZ4 APCu serializer ABI", APC_SERIALIZER_ABI);
+    const char *serializer = zend_ini_string("apc.serializer", sizeof("apc.serializer")-1, 0);
+
+    if (serializer == NULL) {
+        php_info_print_table_row(2, "APCu serializer", "APCu extension not loaded");
+    } else if (strcmp(serializer, "lz4") == 0) {
+        php_info_print_table_row(2, "APCu serializer", "lz4 active");
+    } else {
+        php_info_print_table_row(2, "APCu serializer", "lz4 inactive");
+    }
+
+    php_info_print_table_row(2, "APCu serializer interface version", APC_SERIALIZER_ABI);
+#else
+    php_info_print_table_row(2, "APCu serializer support", "not built");
 #endif
     php_info_print_table_end();
 #if PHP_MAJOR_VERSION >= 7 && defined(HAVE_APCU_SUPPORT)

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -1,17 +1,65 @@
 --TEST--
 Test phpinfo() displays lz4 info
 --SKIPIF--
+<?php if (!extension_loaded('lz4')) die('skip'); ?>
 --FILE--
 <?php
-if (!extension_loaded('lz4')) {
-    dl('lz4.' . PHP_SHLIB_SUFFIX);
+$ref = new ReflectionExtension('lz4');
+ob_start();
+$ref->info();
+$info = ob_get_contents();
+ob_end_clean();
+// skip uninteresting lines
+$lines = [];
+foreach(explode("\n", $info) as $line) {
+    if ($line && $line !== 'lz4') {
+        $lines[] = $line;
+    }
 }
+$verNum = '(([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2}))';
 
-phpinfo();
+if (count($lines) >= 4) {
+    echo preg_match('/^Extension\sversion\s\=\>\s'.$verNum.'$/', $lines[0]) ? "Ext version OK\n" : "Fail\n";
+    $libLz4 = '(bundled|external)';
+    $hasApcu = null;
+    if (file_exists($configH = dirname(__DIR__) . '/config.h')) {
+        $configH = file_get_contents($configH);
+        $libLz4 = preg_match('/define\sHAVE_BUNDLED_LZ4\s1/', $configH) ? 'bundled' : 'external';
+        $hasApcu = PHP_MAJOR_VERSION > 5 && preg_match('/define\sHAVE_APCU_SUPPORT\s1/', $configH) ? true : false;
+    }
+    echo preg_match('/^LZ4\slibrary\s\=\>\s'.$libLz4.'$/', $lines[1]) ? "Bundled/external LZ4 OK\n" : "Fail\n";
+    echo preg_match('/^LZ4\slibrary\sversion\s\=\>\s'.$verNum.'$/', $lines[2]) ? "LZ4 version OK\n" : "Fail\n";
+
+    if ($hasApcu === null) {
+        echo "Apcu OK\n"; // just assume it is okay
+    } else if ($hasApcu) {
+        if (substr($lines[3], 0, 18) !== 'APCu serializer =>') {
+            echo "Fail\n";
+        } else {
+            $fail = '';
+            $value = substr($lines[3], 19);
+            if (!extension_loaded('apcu')) {
+                if ($value !== 'APCu extension not loaded') {
+                    $fail .= 'should be not loaded ';
+                }
+            } else if ($value !== (ini_get('apc.serializer') === 'lz4' ? 'lz4 active' : 'lz4 inactive')) {
+                $fail .= 'active/inactive mismatch ';
+            }
+            if (
+                !isset($lines[4])
+                ||
+                !preg_match('/^APCu\sserializer\sinterface\sversion\s\=\>\s([0-9])/', $lines[4])
+            ) {
+                $fail .= 'ABI ';
+            }
+            echo !$fail ? "Apcu OK\n" : ("Fail: " . $fail . "");
+        }
+    } else {
+        echo ($lines[3] == 'APCu serializer support => not built') ? "Apcu OK\n" : "Fail: not built\n";
+    }
+}
 --EXPECTF--
-%a
-lz4
-
-LZ4 support => enabled
-Extension Version => %d.%d.%d
-%a
+Ext version OK
+Bundled/external LZ4 OK
+LZ4 version OK
+Apcu OK


### PR DESCRIPTION
Similar phpinfo improvements as with zstd and brotli + fix compiler warnings while here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extension information now reports the installed LZ4 version and whether the bundled or external library is in use.
  * Added detailed APCu serializer status and interface information to diagnostic output.

* **Bug Fixes**
  * Improved bundled LZ4 build configuration detection.
  * Enhanced compatibility when handling compressed data through the APCu serializer.

* **Tests**
  * Expanded validation of version reporting, library configuration, and APCu serializer support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->